### PR TITLE
[Select] Added support to `multiple` props

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -17,7 +17,7 @@ export default ({input: {name, value, onChange, ...restInput}, meta, label, form
 				name={name}
 				onChange={onChange}
 				inputProps={restInput}
-				value={value}
+       				value={(rest.multiple ? (!!value && value !== '') ? value : [] : value)}
 			/>
 
 			{showError &&

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -17,7 +17,7 @@ export default ({input: {name, value, onChange, ...restInput}, meta, label, form
 				name={name}
 				onChange={onChange}
 				inputProps={restInput}
-       				value={(rest.multiple ? (!!value && value !== '') ? value : [] : value)}
+				value={(rest.multiple ? (!!value && value !== '') ? value : [] : value)}
 			/>
 
 			{showError &&


### PR DESCRIPTION
If you try to use the props `multiple` in the current build, the component won't work, since it expect an array as initial `value` and instead will receive either `null` or `''`