### PR TITLE
TextField: render helperText if no error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,1 @@
+singleQuote: true

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
-import Checkbox from '@material-ui/core/Checkbox';
-import {FieldRenderProps} from 'react-final-form';
+import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
+import { FieldRenderProps } from 'react-final-form';
 
+export type Props = FieldRenderProps<HTMLInputElement> & CheckboxProps;
 
-const CheckboxWrapper: React.SFC<FieldRenderProps> = ({
-	input: {checked, name, onChange, ...restInput},
+const CheckboxWrapper: React.SFC<Props> = ({
+	input: { checked, name, onChange, onFocus, onBlur },
 	meta,
 	...rest
 }) => (
 	<Checkbox
 		{...rest}
 		name={name}
-		inputProps={restInput}
+		inputProps={{ onFocus, onBlur }}
 		onChange={onChange}
 		checked={checked}
 	/>

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -1,11 +1,16 @@
 import * as React from 'react';
-import {FieldRenderProps} from 'react-final-form';
-import Input from '@material-ui/core/Input';
+import { FieldRenderProps } from 'react-final-form';
+import Input, { InputProps } from '@material-ui/core/Input';
 import FormHelperText from '@material-ui/core/FormHelperText';
 
+export type Props = FieldRenderProps<HTMLTextAreaElement | HTMLInputElement> &
+	InputProps;
 
-const InputWrapper: React.SFC<FieldRenderProps> = ({input: {name, onChange, value, ...restInput}, meta, ...rest}) => {
-	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
+const InputWrapper: React.SFC<Props> = ({ input, meta, ...rest }) => {
+	const { name, value, onChange, onBlur, onFocus } = input;
+	const showError =
+		((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) &&
+		meta.touched;
 
 	return (
 		<>
@@ -13,16 +18,16 @@ const InputWrapper: React.SFC<FieldRenderProps> = ({input: {name, onChange, valu
 				{...rest}
 				name={name}
 				error={showError}
-				inputProps={restInput}
+				inputProps={{ onBlur, onFocus }}
 				onChange={onChange}
 				value={value}
 			/>
 
-			{showError &&
+			{showError && (
 				<FormHelperText>
 					{meta.error || meta.submitError}
 				</FormHelperText>
-			}
+			)}
 		</>
 	);
 };

--- a/src/Radio.tsx
+++ b/src/Radio.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
-import Radio from '@material-ui/core/Radio';
-import {FieldRenderProps} from 'react-final-form';
+import Radio, { RadioProps } from '@material-ui/core/Radio';
+import { FieldRenderProps } from 'react-final-form';
 
+export type Props = FieldRenderProps<HTMLInputElement> & RadioProps;
 
-const RadioWrapper: React.SFC<FieldRenderProps> = ({
-	input: {checked, value, name, onChange, ...restInput},
+const RadioWrapper: React.SFC<Props> = ({
+	input: { checked, value, name, onChange, onFocus, onBlur },
 	meta,
 	...rest
 }) => (
 	<Radio
 		{...rest}
 		name={name}
-		inputProps={restInput}
+		inputProps={{ onFocus, onBlur }}
 		onChange={onChange}
 		checked={checked}
 		value={value}

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -1,25 +1,29 @@
 import * as React from 'react';
-import Select from '@material-ui/core/Select';
+import Select, { SelectProps } from '@material-ui/core/Select';
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
-import {FormControlProps} from '@material-ui/core/FormControl';
-import {FieldRenderProps} from 'react-final-form';
+import { FormControlProps } from '@material-ui/core/FormControl';
+import { FieldRenderProps } from 'react-final-form';
 
+export type Props = FieldRenderProps<
+	HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+> &
+	SelectProps & {
+		label: string;
+		formControlProps: FormControlProps;
+	};
 
-interface FormHelperTextWrapperProps extends FieldRenderProps {
-	label: string,
-	formControlProps: FormControlProps,
-}
-
-const FormHelperTextWrapper: React.SFC<FormHelperTextWrapperProps> = ({
-    input: {name, value, onChange, ...restInput},
-    meta,
+const FormHelperTextWrapper: React.SFC<Props> = ({
+	input: { name, value, onChange, onBlur, onFocus },
+	meta,
 	label,
-    formControlProps,
-    ...rest
+	formControlProps,
+	...rest
 }) => {
-	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
+	const showError =
+		((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) &&
+		meta.touched;
 
 	return (
 		<FormControl {...formControlProps} error={showError}>
@@ -29,13 +33,15 @@ const FormHelperTextWrapper: React.SFC<FormHelperTextWrapperProps> = ({
 				{...rest}
 				name={name}
 				onChange={onChange}
-				inputProps={restInput}
+				inputProps={{ onBlur, onFocus }}
 				value={value}
 			/>
 
-			{showError &&
-				<FormHelperText>{meta.error || meta.submitError}</FormHelperText>
-			}
+			{showError && (
+				<FormHelperText>
+					{meta.error || meta.submitError}
+				</FormHelperText>
+			)}
 		</FormControl>
 	);
 };

--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -1,18 +1,29 @@
 import * as React from 'react';
-import {FieldRenderProps} from 'react-final-form';
-import TextField from '@material-ui/core/TextField';
+import { FieldRenderProps } from 'react-final-form';
+import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 
+export type Props = FieldRenderProps<
+	HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+> &
+	TextFieldProps;
 
-const TextFieldWrapper: React.SFC<FieldRenderProps> = ({input: {name, onChange, value, ...restInput}, meta, ...rest}) => {
-	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
+const TextFieldWrapper: React.SFC<Props> = ({
+	input: { name, onChange, value, onFocus, onBlur },
+	meta,
+	helperText,
+	...rest
+}) => {
+	const showError =
+		((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) &&
+		meta.touched;
 
 	return (
 		<TextField
 			{...rest}
 			name={name}
-			helperText={showError ? meta.error || meta.submitError : undefined}
+			helperText={showError ? meta.error || meta.submitError : helperText}
 			error={showError}
-			inputProps={restInput}
+			inputProps={{ onFocus, onBlur }}
 			onChange={onChange}
 			value={value}
 		/>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
-import TextField from './TextField';
-import Checkbox from './Checkbox';
-import Radio from './Radio';
-import Select from './Select';
-import Input from './Input';
-
-
-export {TextField, Checkbox, Radio, Select, Input};
+export { default as TextField, Props as TextFieldProps } from "./TextField";
+export { default as Checkbox, Props as CheckboxProps } from "./Checkbox";
+export { default as Radio, Props as RadioProps } from "./Radio";
+export { default as Select, Props as SelectProps } from "./Select";
+export { default as Input, Props as InputProps } from "./Input";


### PR DESCRIPTION
If one passes a `helperText` to `TextField` it should actually be rendered if no error is present. If there is an error, the error message should be rendered instead.

The TypeScript compiler complained that `FieldRenderProps` is a generic type but was used without type information. So I've added the types of the corresponding `HTML*Element`s.

While at it I've also added the properties of the corresponding MUI components to the properties to make the `...rest` properties type-safe.

I've exported the properties together with their components.

Also, to make TypeScript happy, I had to manually destructure `{ onBlur, onFocus }` from the input properties because it would refuse to destructure from a union type.

Finally I've added `.editorconfig` and `.prettierrc` to make formatting more consistent.