### PR TITLE
Compatibility with react-final-form 4.1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^1.0.0 || ^2.0.0 || ^3.0.0",
-    "final-form": "^4.0.0",
-    "react": "^15.0.0 || ^16.0.0",
-    "react-final-form": "^3.0.0 || ^4.0.0"
+    "final-form": "^4.11.0",
+    "react": "^16.3.0",
+    "react-final-form": "^4.1.0"
   },
   "devDependencies": {
     "@material-ui/core": "^3.2.2",
-    "final-form": "^4.0.0",
+    "final-form": "^4.12.0",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
-    "react-final-form": "^4.0.2",
+    "react-final-form": "^4.1.0",
     "ts-loader": "^5.2.2",
     "typescript": "^3.1.3",
     "webpack": "^4.12.0",

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -3,7 +3,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import {FieldRenderProps} from 'react-final-form';
 
 
-const CheckboxWrapper: React.SFC<FieldRenderProps> = ({
+const CheckboxWrapper: React.SFC<FieldRenderProps<any>> = ({
 	input: {checked, name, onChange, ...restInput},
 	meta,
 	...rest

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -4,7 +4,7 @@ import Input from '@material-ui/core/Input';
 import FormHelperText from '@material-ui/core/FormHelperText';
 
 
-const InputWrapper: React.SFC<FieldRenderProps> = ({input: {name, onChange, value, ...restInput}, meta, ...rest}) => {
+const InputWrapper: React.SFC<FieldRenderProps<any>> = ({input: {name, onChange, value, ...restInput}, meta, ...rest}) => {
 	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
 
 	return (

--- a/src/Radio.tsx
+++ b/src/Radio.tsx
@@ -3,7 +3,7 @@ import Radio from '@material-ui/core/Radio';
 import {FieldRenderProps} from 'react-final-form';
 
 
-const RadioWrapper: React.SFC<FieldRenderProps> = ({
+const RadioWrapper: React.SFC<FieldRenderProps<any>> = ({
 	input: {checked, value, name, onChange, ...restInput},
 	meta,
 	...rest

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -7,9 +7,9 @@ import {FormControlProps} from '@material-ui/core/FormControl';
 import {FieldRenderProps} from 'react-final-form';
 
 
-interface FormHelperTextWrapperProps extends FieldRenderProps {
-	label: string,
-	formControlProps: FormControlProps,
+interface FormHelperTextWrapperProps extends FieldRenderProps<any> {
+	label?: string,
+	formControlProps?: FormControlProps,
 }
 
 const FormHelperTextWrapper: React.SFC<FormHelperTextWrapperProps> = ({

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -1,5 +1,7 @@
+// Based on: https://github.com/rainerschuster/final-form-material-ui/blob/master/src/Select.tsx
+
 import * as React from 'react';
-import Select from '@material-ui/core/Select';
+import MuiSelect from '@material-ui/core/Select';
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
@@ -7,37 +9,37 @@ import {FormControlProps} from '@material-ui/core/FormControl';
 import {FieldRenderProps} from 'react-final-form';
 
 
-interface FormHelperTextWrapperProps extends FieldRenderProps<any> {
-	label?: string,
-	formControlProps?: FormControlProps,
+interface SelectProps extends FieldRenderProps<any, any> {
+  native?: boolean,
+  label?: string,
+  formControlProps?: FormControlProps,
 }
 
-const FormHelperTextWrapper: React.SFC<FormHelperTextWrapperProps> = ({
-    input: {name, value, onChange, ...restInput},
-    meta,
-	label,
-    formControlProps,
-    ...rest
+export const Select: React.FunctionComponent<SelectProps> = ({
+  input: {name, value, onChange, ...restInput},
+  meta,
+  label,
+  formControlProps,
+  ...rest
 }) => {
-	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
+  const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
 
-	return (
-		<FormControl {...formControlProps} error={showError}>
-			<InputLabel htmlFor={name}>{label}</InputLabel>
+  return (
+    <FormControl {...formControlProps} error={showError}>
+      <InputLabel htmlFor={name}>{label}</InputLabel>
 
-			<Select
-				{...rest}
-				name={name}
-				onChange={onChange}
-				inputProps={restInput}
-				value={value}
-			/>
-
-			{showError &&
-				<FormHelperText>{meta.error || meta.submitError}</FormHelperText>
-			}
-		</FormControl>
-	);
+      <MuiSelect
+        name={name}
+        onChange={onChange}
+        inputProps={restInput}
+        value={value}
+        {...rest}
+      />
+      {showError &&
+        <FormHelperText>{meta.error || meta.submitError}</FormHelperText>
+      }
+    </FormControl>
+  );
 };
 
-export default FormHelperTextWrapper;
+export default Select

--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -3,7 +3,7 @@ import {FieldRenderProps} from 'react-final-form';
 import TextField from '@material-ui/core/TextField';
 
 
-const TextFieldWrapper: React.SFC<FieldRenderProps> = ({input: {name, onChange, value, ...restInput}, meta, ...rest}) => {
+const TextFieldWrapper: React.SFC<FieldRenderProps<any>> = ({input: {name, onChange, value, ...restInput}, meta, ...rest}) => {
 	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
 
 	return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,12 +16,12 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.1.2":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.0.tgz#d0f6cd4f1b34515782e7e328e5cf54f8db391769"
-  integrity sha512-7K/aLEgWRClfSCCIXVYw07d6jnBMDwr+NGIfNJtCIlw5FcnP1C2GMDPovn8LNZtZuMf2gWzsCz8+CINad05Dow==
+"@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4":
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.3.tgz#79888e452034223ad9609187a0ad1fe0d2ad4bdc"
+  integrity sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==
   dependencies:
-    regenerator-runtime "^0.12.0"
+    regenerator-runtime "^0.13.2"
 
 "@material-ui/core@^3.2.2":
   version "3.2.2"
@@ -1096,10 +1096,12 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
-final-form@^4.0.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.10.0.tgz#6179bca7676925202510e9877eb1ad2ad1cd3460"
-  integrity sha512-pq/LKcynfI7CWJUX/YlMKwL6Xf5s6SxfjwFT6Saz4Qnwce5flShPQW7IOpxauy/PzD9LMwH/0qI5fXnNaBlOJg==
+final-form@^4.12.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.12.0.tgz#1844e2a3bc9789d51115c76a94d0ea6a19e219c0"
+  integrity sha512-z1fSzDNmIBlDjRMaluM3WgDbcwCFpPm7mvopplgXGMRS49MXR+1n//lteLwPURdGQNOZhWm3GwiEJanEHCItww==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
 
 find-cache-dir@^1.0.0:
   version "1.0.0"
@@ -2391,12 +2393,12 @@ react-event-listener@^0.6.2:
     prop-types "^15.6.0"
     warning "^4.0.1"
 
-react-final-form@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-4.0.2.tgz#fa829d7fb60dcc168804bf2edda58f3d62c4607b"
-  integrity sha512-EdFWrT8nMWu5sHViuZ/VmlaYT+mLu/q5TMDWZZj5gnssUAWfgcila0QpptFNDg6+qNtepGgFh5ZPASlivoEXUA==
+react-final-form@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-4.1.0.tgz#4e1b513de164771b2b824f3fb9c0548014255971"
+  integrity sha512-O8p1EPQ/PFWNcX3bYGsLzuo/KnGeNfGfFi2UAX8jXLXrGcGdTfZMnyo/DFHdEKA9aKso61d/PHekQ9sst0cOmw==
   dependencies:
-    "@babel/runtime" "^7.1.2"
+    "@babel/runtime" "^7.3.4"
 
 react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -2461,6 +2463,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
react-final-form 4.1.0 made FieldRenderProps generic, which leads to incompatibility. This patch fixes this and raises the versions of the required peer dependencies.