### PR TITLE
feat: allow helperText when there is no error

### DIFF
--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -10,7 +10,7 @@ const TextFieldWrapper: React.SFC<FieldRenderProps> = ({input: {name, onChange, 
 		<TextField
 			{...rest}
 			name={name}
-			helperText={showError ? meta.error || meta.submitError : undefined}
+			helperText={showError ? meta.error || meta.submitError : rest.helperText}
 			error={showError}
 			inputProps={restInput}
 			onChange={onChange}


### PR DESCRIPTION
closes #22

As mentioned in #22, It's reasonable to show the passed `helperText` if there is no error.